### PR TITLE
fix parsing code with hashbangs (#!)

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,7 +53,11 @@ function handleIncomingSourceMap (originalCode) {
 }
 
 function applyUnassertWithSourceMap (code, filepath) {
-    var ast = acorn.parse(code, { sourceType: 'module', locations: true });
+    var ast = acorn.parse(code, {
+      sourceType: 'module',
+      locations: true,
+      allowHashBang: true
+    });
     var inMap = handleIncomingSourceMap(code);
     var instrumented = escodegen.generate(unassert(ast), {
         sourceMap: filepath,
@@ -70,7 +74,10 @@ function applyUnassertWithSourceMap (code, filepath) {
 }
 
 function applyUnassertWithoutSourceMap (code) {
-    var ast = acorn.parse(code, { sourceType: 'module' });
+    var ast = acorn.parse(code, {
+      sourceType: 'module',
+      allowHashBang: true
+    });
     return escodegen.generate(unassert(ast));
 }
 

--- a/test/test.js
+++ b/test/test.js
@@ -183,3 +183,23 @@ describe('when incoming code is JSON file', function() {
         file.pipe(stream);
     });
 });
+
+
+describe('when incoming code contains #! hash bang', function() {
+    var stream = unassertify(
+        '/tmp/JSONStream.js',
+        { _flags: {} }
+    );
+
+    it('should ignore hashbang', function(done) {
+        var output = '';
+        stream.on('data', function(buf) {
+            output += buf;
+        });
+        stream.on('end', function() {
+            // We didn't crash while parsing!
+            done();
+        });
+        stream.end('#!/usr/bin/env node\n\nvar assert = require("assert"); assert(10 == 10);');
+    });
+});


### PR DESCRIPTION
Some Node modules can also be used as a CLI, and include a #! at the top
of the file to make that happen. [JSONStream][] is one example.

Previously these modules would crash `unassertify`. This patch fixes
that by using Acorn's `allowHashBang` option, which will ignore
hashbangs in the input.

[JSONStream]: https://github.com/dominictarr/JSONStream/blob/master/index.js