### PR TITLE
Skip parsing if file doesn't contain assertions

### DIFF
--- a/index.js
+++ b/index.js
@@ -87,6 +87,11 @@ function shouldProduceSourceMap (options) {
     return (options && options._flags && options._flags.debug);
 }
 
+function containsAssertions (src) {
+    // Matches both `assert` and `power-assert`.
+    return src.indexOf('assert') !== -1;
+}
+
 module.exports = function unassertify (filepath, options) {
     if (path.extname(filepath) === '.json') {
         return through();
@@ -100,11 +105,13 @@ module.exports = function unassertify (filepath, options) {
     }
 
     function end() {
-        if (shouldProduceSourceMap(options)) {
+        if (!containsAssertions(data)) {
+            stream.queue(data);
+        } else if (shouldProduceSourceMap(options)) {
             stream.queue(applyUnassertWithSourceMap(data, filepath));
         } else {
             stream.queue(applyUnassertWithoutSourceMap(data));
-        }        
+        }
         stream.queue(null);
     }
 

--- a/test/fixtures/func/no-assert.js
+++ b/test/fixtures/func/no-assert.js
@@ -1,0 +1,1 @@
+contains some invalid code to make sure that this did not get parsed

--- a/test/test.js
+++ b/test/test.js
@@ -43,6 +43,17 @@ describe('unassertify', function () {
             done();
         }));
     });
+    it('skips files that do not contain assertions', function (done) {
+        var filename = path.join(__dirname, 'fixtures', 'func', 'no-assert.js');
+        fs.createReadStream(filename)
+            .pipe(unassertify(filename, {}))
+            .pipe(es.wait(function(err, data) {
+                assert(!err);
+                var code = data.toString('utf-8');
+                assert(! /assert/.test(code));
+                done();
+            }));
+    });
 });
 
 


### PR DESCRIPTION
Unassertify is quite an expensive transform, because it does full
parsing and code generation. That only needs to be done for files that
contain assertions, though. This patch adds a quick check: if the string
`assert` does not even occur in the file, we'll just skip it, saving
some time.